### PR TITLE
Expand compatibility using qtpy for PyQt6, PyQt5, PySide6, and PySide2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,164 @@ QtWaitingSpinner.exe
 build-QtWaitingSpinnerTest-Desktop-Debug*
 build-QtWaitingSpinnerTest-GCC-Debug*
 build-QtWaitingSpinnerTest-Desktop_Qt_5_3_GCC_64bit-Debug*
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ The following properties can all be controlled directly through their correspond
 * The percentage fade of the "trail"
 * The minimum opacity of the "trail"
 
+This project uses the [qtpy](https://github.com/spyder-ide/qtpy) abstraction layer to support PyQt6, PyQt5, PySide6, and PySide2 backends.
+
 ### Usage
 
 Despite being highly configurable, QtWaitingSpinner is extremely easy to use and, to make things even easier, the "QtWaitingSpinnerTest" application can assist you in determining the exact shape, size and color you'd like your spinner to have.

--- a/demo.py
+++ b/demo.py
@@ -26,8 +26,8 @@ SOFTWARE.
 
 import sys
 
-from PyQt6.QtCore import *
-from PyQt6.QtWidgets import *
+from qtpy.QtCore import *
+from qtpy.QtWidgets import *
 
 from waitingspinnerwidget import QtWaitingSpinner
 

--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,6 @@ setup(
     license='MIT',
     author='Luca Weiss',
     author_email='luca@z3ntu.xyz',
-    description='A waiting spinner for PyQt6', requires=['PyQt6']
+    description='A waiting spinner for Python Qt',
+    requires=['qtpy'],
 )

--- a/waitingspinnerwidget.py
+++ b/waitingspinnerwidget.py
@@ -27,9 +27,9 @@ SOFTWARE.
 
 import math
 
-from PyQt6.QtCore import Qt, QTimer, QRect
-from PyQt6.QtGui import QColor, QPainter
-from PyQt6.QtWidgets import QWidget
+from qtpy.QtCore import Qt, QTimer, QRect
+from qtpy.QtGui import QColor, QPainter
+from qtpy.QtWidgets import QWidget
 
 
 class QtWaitingSpinner(QWidget):


### PR DESCRIPTION
The [qtpy](https://github.com/spyder-ide/qtpy) abstraction layer allows projects to simultaneously support backends including PyQt6, PyQt5, PySide6, and PySide2.

This is a lot more convenient than users having to make edits like this one https://github.com/z3ntu/QtWaitingSpinner/pull/6 to the code if they happen to use a different version of Qt, and it's a lot nicer than asking users to check out a specific commit to use the code - now one install works for all situations.

I've tested this PR locally, and the `demo.py` script runs well for all four backends. I have another branch where I've added CI tests with github actions and can submit that as a separate PR if you like.


